### PR TITLE
Allow to add attachments to sharing email

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ clearance = require 'cozy-clearance'
 clearanceCtl = clearance.controller
     mailSubject: (options) -> # options.doc , options.url
     mailTemplate: (options) -> # options.doc , options.url
+    attachments: optional array of attachments
 
 'docid':
     param: # fetch and save in req.doc

--- a/controller.coffee
+++ b/controller.coffee
@@ -42,7 +42,7 @@ module.exports = (options) ->
     sendMail = (doc, key, cb) ->
         rule = doc.clearance.filter((rule) -> rule.key is key)[0]
 
-        doc.getPublicURL (err, url) =>
+        doc.getPublicURL (err, url) ->
             return cb err if err
 
             urlObject = urlHelpers.parse url
@@ -60,6 +60,9 @@ module.exports = (options) ->
                     subject: subject
                     content: url
                     html: htmlContent
+
+                if options.attachments
+                    emailInfo.attachments = options.attachments
 
                 CozyAdapter.sendMailFromUser emailInfo, cb
 
@@ -85,8 +88,8 @@ module.exports = (options) ->
                 return rule
 
             req.doc.updateAttributes clearance: newClearance, (err) ->
-                    return next err if err
-                    res.send req.doc
+                return next err if err
+                res.send req.doc
 
     out.getEmailsFromContactFields =  (contact) ->
         emails = contact.datapoints?.filter (dp) -> dp.name is 'email'

--- a/controller.coffee
+++ b/controller.coffee
@@ -54,6 +54,7 @@ module.exports = (options) ->
                 (cb) -> mailSubject emailOptions, cb
                 (cb) -> mailTemplate emailOptions, cb
             ], (err, results) ->
+                return cb err if err
                 [subject, htmlContent] = results
                 emailInfo =
                     to: rule.email


### PR DESCRIPTION
This change is related to cozy/cozy-photos#166
Once it has been merged and published, I'll push the code to attach Cozy logo to sharing emails in photos.